### PR TITLE
add support for "must return particle even if blocked" list for particleEngine

### DIFF
--- a/api/src/main/java/dev/nolij/nolijium/impl/config/NolijiumConfigImpl.java
+++ b/api/src/main/java/dev/nolij/nolijium/impl/config/NolijiumConfigImpl.java
@@ -16,6 +16,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Consumer;
 
 public class NolijiumConfigImpl implements Cloneable {
@@ -264,6 +265,12 @@ public class NolijiumConfigImpl implements Cloneable {
 		DEFAULT: `[ ]`""")
 	public ArrayList<String> hideParticlesByID = new ArrayList<>();
 	
+	@ZsonField(comment = """
+		Some particles are required to be created to prevent crashes. These particles must be added to this list.
+		Also supports modded particles.
+		DEFAULT: `[ "minecraft:firework" ]`""")
+	public ArrayList<String> mustBeCreatedParicleIDs = new ArrayList<>(List.of("minecraft:firework"));
+
 	@ZsonField(comment = """
 		Higher values cycle faster. Lower values cycle slower.
 		DEFAULT: `0.5`""")

--- a/common/src/main/java/dev/nolij/nolijium/common/NolijiumCommon.java
+++ b/common/src/main/java/dev/nolij/nolijium/common/NolijiumCommon.java
@@ -11,6 +11,7 @@ import dev.nolij.nolijium.mixin.common.LightTextureAccessor;
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
 import net.minecraft.ChatFormatting;
+import net.minecraft.ResourceLocationException;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.toasts.AdvancementToast;
 import net.minecraft.client.gui.components.toasts.RecipeToast;
@@ -31,6 +32,7 @@ import net.minecraftforge.fml.common.Mod;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.stream.Collectors;
@@ -88,6 +90,7 @@ public class NolijiumCommon implements INolijiumImplementation {
 	}
 	
 	public static Set<ResourceLocation> blockedParticleTypeIDs = Set.of();
+	public static Set<ResourceLocation> mustBeCreatedParticleTypeIDs = Set.of();
 	
 	@Override
 	public void onConfigReload(NolijiumConfigImpl config) {
@@ -95,6 +98,19 @@ public class NolijiumCommon implements INolijiumImplementation {
 		blockedParticleTypeIDs = config.hideParticlesByID
 			.stream()
 			.map(ResourceLocation::tryParse)
+			.collect(Collectors.toUnmodifiableSet());
+		
+		mustBeCreatedParticleTypeIDs = config.mustBeCreatedParicleIDs
+			.stream()
+			.map(idEntry->{
+				try {
+					return ResourceLocation.parse(idEntry);
+				}catch(ResourceLocationException e) {
+					Nolijium.LOGGER.error("Unable to parse mustBeCreatedParicleIDs entry for particle id: {}", idEntry, e);
+				}
+				return null;
+			})
+			.filter(Objects::nonNull)
 			.collect(Collectors.toUnmodifiableSet());
 		
 		//noinspection ConstantValue


### PR DESCRIPTION
Add list for particles that must be created and returned from createParticle method in ParticleEngine but do not need to be added to the particle list.

supports fixing #29 through default return list (does not patch vanilla handling to support null)